### PR TITLE
Fix AudioWorklet bundling manifest

### DIFF
--- a/apps/web/src/audio/engine.ts
+++ b/apps/web/src/audio/engine.ts
@@ -1,0 +1,42 @@
+/* eslint-disable no-console */
+export type AudioWorkletModuleId = keyof typeof WORKLET_MANIFEST;
+
+const WORKLET_MANIFEST = {
+  eq: './worklets/eq-processor.ts',
+} as const satisfies Record<string, string>;
+
+const WORKLET_URLS: Record<AudioWorkletModuleId, string> = Object.fromEntries(
+  Object.entries(WORKLET_MANIFEST).map(([moduleId, relativePath]) => {
+    const normalizedPath = relativePath.endsWith('?worker&url')
+      ? relativePath
+      : `${relativePath}?worker&url`;
+
+    return [moduleId, new URL(normalizedPath, import.meta.url).href];
+  }),
+) as Record<AudioWorkletModuleId, string>;
+
+export class AudioEngine {
+  constructor(private readonly context: AudioContext) {
+    if (!('audioWorklet' in context)) {
+      throw new Error('AudioWorklet is not available in this AudioContext.');
+    }
+  }
+
+  async addModule(moduleId: AudioWorkletModuleId): Promise<void> {
+    const moduleUrl = WORKLET_URLS[moduleId];
+
+    if (!moduleUrl) {
+      throw new Error(`AudioWorklet module "${moduleId}" is not registered in the manifest.`);
+    }
+
+    await this.context.audioWorklet.addModule(moduleUrl);
+  }
+
+  async addAllModules(): Promise<void> {
+    await Promise.all(
+      (Object.keys(WORKLET_URLS) as AudioWorkletModuleId[]).map((moduleId) => this.addModule(moduleId)),
+    );
+  }
+}
+
+export const AUDIO_WORKLET_URLS = WORKLET_URLS;

--- a/apps/web/src/audio/worklets/eq-processor.ts
+++ b/apps/web/src/audio/worklets/eq-processor.ts
@@ -1,0 +1,32 @@
+/**
+ * Simple equalizer AudioWorklet processor placeholder.
+ *
+ * This pass-through processor exists so the Vite build emits a
+ * bundled worklet file that can be loaded by the audio engine.
+ */
+class EqProcessor extends AudioWorkletProcessor {
+  process(inputs: Float32Array[][], outputs: Float32Array[][]): boolean {
+    const inputChannelData = inputs[0];
+    const outputChannelData = outputs[0];
+
+    if (!inputChannelData || !outputChannelData) {
+      return true;
+    }
+
+    for (let channel = 0; channel < inputChannelData.length; channel += 1) {
+      const input = inputChannelData[channel];
+      const output = outputChannelData[channel] ?? new Float32Array(input.length);
+
+      if (outputChannelData[channel] !== output) {
+        outputChannelData[channel] = output;
+      }
+
+      output.set(input);
+    }
+
+    return true;
+  }
+}
+
+registerProcessor('eq-processor', EqProcessor);
+export {};

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from 'vite';
+
+export default defineConfig({
+  worker: {
+    format: 'es',
+    rollupOptions: {
+      output: {
+        entryFileNames: (chunkInfo) => {
+          if (chunkInfo.name?.includes('worklets/')) {
+            return 'assets/[name].js';
+          }
+
+          return 'assets/[name]-[hash].js';
+        },
+      },
+    },
+  },
+});


### PR DESCRIPTION
## Summary
- update the audio engine to resolve AudioWorklet modules via Vite `?worker&url` bundle URLs
- add a placeholder EQ AudioWorklet processor that will be emitted by the build pipeline
- configure Vite to emit deterministic file names for bundled worklet assets

## Testing
- not run (not available in container)


------
https://chatgpt.com/codex/tasks/task_e_68db9b89a3bc832f98dbf0332716dff8